### PR TITLE
Small correction in d_icd_diagnoses.md

### DIFF
--- a/content/mimictables/d_icd_diagnoses.md
+++ b/content/mimictables/d_icd_diagnoses.md
@@ -21,7 +21,7 @@ toc = "true"
 
 **Links to:**
 
-* DIAGNOSES_ICD ON `ICD9_CODE`
+* D_ICD_DIAGNOSES ON `ICD9_CODE`
 
 <!-- # Important considerations -->
 


### PR DESCRIPTION
ICD9 code links to D_ICD_DIAGNOSES, not DIAGNOSES_ICD