### PR TITLE
Added ROW_ID

### DIFF
--- a/content/mimictables/prescriptions.md
+++ b/content/mimictables/prescriptions.md
@@ -32,7 +32,8 @@ toc = "true"
 # Table columns
 
 Name | Postgres data type 
----- | ---- 
+---- | ----
+ROW\_ID | INT
 SUBJECT\_ID | INT
 HADM\_ID | INT
 ICUSTAY\_ID | INT


### PR DESCRIPTION
ROW_ID is in the table itself but was missing from the list of columns in the documentation.