### PR TITLE
add explanation of ISERROR column

### DIFF
--- a/content/mimictables/noteevents.md
+++ b/content/mimictables/noteevents.md
@@ -65,6 +65,8 @@ Identifiers which specify the patient: `SUBJECT_ID` is unique to a patient and `
 
 ## `ISERROR`
 
+A '1' in the `ISERROR` column indicates that a physician has identified this note as an error. 
+
 ## `TEXT`
 
 `TEXT` contains the note text.


### PR DESCRIPTION
Used http://opendata.stackexchange.com/questions/6262/what-is-the-iserror-column-in-mimic-iiis-noteevents-table as a reference and decided to keep it simple, no need to explain about the software. 