### PR TITLE
typo correction in instructions

### DIFF
--- a/content/tutorials/install-mimic-locally-ubuntu.md
+++ b/content/tutorials/install-mimic-locally-ubuntu.md
@@ -172,7 +172,7 @@ Before going further, you should grant all privileges needed to the mimic user, 
 grant select on all tables in schema mimiciii to mimicuser;
 grant usage on schema mimiciii to mimicuser;
 grant connect on database mimic to mimicuser;
-alter user mimic nosuperuser;
+alter user mimicuser nosuperuser;
 ```
 
 Now try, for example, counting the number of patients in the database:


### PR DESCRIPTION
It is a minor thing. In the section for revoking the superuser access, the code in the page reads
`alter user mimic nosuperuser;`
but `mimic` refers to the table, not the user. Hence ,the correct form should be
`alter user mimicuser nosuperuser;`