### PR TITLE
Remove dead link to publications

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -12,5 +12,4 @@ toc = "False"
 * [About MIMIC](/about/mimic/)
 * [Release notes](/about/releasenotes/)
 * [Roadmap](/about/roadmap/)
-* [Publications](/about/publications/)
 * [Acknowledgements](/about/acknowledgements/)


### PR DESCRIPTION
The link to publications should be removed as it no longer exists and we've received emails asking where the page went. See more information here: https://github.com/MIT-LCP/mimic-code/issues/763.