### PR TITLE
Changes wording of credentialing suggestions

### DIFF
--- a/content/gettingstarted/access.md
+++ b/content/gettingstarted/access.md
@@ -33,7 +33,7 @@ Prior to requesting access to MIMIC, you will need to complete the CITI “Data 
 - Click "credentialed user" link, then follow the instructions to submit your application for credentialed access. Remember to provide your CITI completion report.
 - When your application has been approved you will receive emails containing instructions for downloading the database from PhysioNetWorks. Approval may take several business days, and will be delayed if your request is missing any required information.
 
-Please be sure to provide all requested information. Submissions that are clearly incomplete, incorrect, or frivolous may be discarded without notice.
+Please be sure to provide all requested information. Submissions that are clearly incomplete, incorrect, or frivolous will be rejected.
 
 If you are a student or a postdoc, you must provide your supervisor’s name and contact information in the "reference" section of the form. If you are not listed in a directory or other easy-to-find page of your organization’s website, please provide the name and contact information of a reference such as a supervisor or colleague. Do not list yourself as reference.
 


### PR DESCRIPTION
This change modifies the wording given to credential applicants. The current wording indicates that some applications may be discarded without notice, but this is not currently true since applications should either be accepted or rejected and in both cases they will receive a notification email.