### PR TITLE
Update instructions for using BigQuery and move it under Getting started.

### DIFF
--- a/content/gettingstarted/_index.md
+++ b/content/gettingstarted/_index.md
@@ -7,10 +7,15 @@ toc = "False"
 
 +++
 
+<!--- NOTE: this only controls the content for the
+/gettingstarted/ page, the sub-headings in the
+page navigation to the left are controlled by the 
+individual .md files --->
+
 # Getting started
 
-* [Overview of the data](/gettingstarted/overview/)
-* [Getting access](/gettingstarted/access/)
-* [Using MIMIC on the Cloud](/gettingstarted/cloud/)
-* [Where to download the data](/gettingstarted/dbsetup/)
+* [Overview](/gettingstarted/overview/)
+* [Requesting access](/gettingstarted/access/)
+* [MIMIC in the Cloud](/gettingstarted/cloud/)
+* [Downloading the database](/gettingstarted/dbsetup/)
 * [MIMIC-III demo](/gettingstarted/demo/)

--- a/content/gettingstarted/cloud.md
+++ b/content/gettingstarted/cloud.md
@@ -1,12 +1,12 @@
 +++
-title = "Cloud"
-linktitle = "Cloud"
+title = "MIMIC in the Cloud"
+linktitle = "MIMIC in the Cloud"
 weight = 3
 toc = false
 
 [menu]
   [menu.main]
-    parent = "About"
+    parent = "Getting started"
 
 +++
 
@@ -88,13 +88,16 @@ BigQuery is a columnar, distributed relational database management system. BigQu
 
 Once you have requested access to using MIMIC-III on BigQuery, you need to "pin" the dataset to see it on the web browser. This adds the dataset to the sidebar in BigQuery. While not required, we do recommend pinning the data for easier navigation.
 
-1. Go to the BigQuery console: http://console.cloud.google.com/bigquery
-2. On the left sidebar, next to "Resources", click "+ ADD DATA", followed by "Pin a project"
+1. Ensure you have added a gmail account to your PhysioNet profile as described above.
+2. Go to the BigQuery console: http://console.cloud.google.com/bigquery while logged into your gmail account.
+3. If you haven't created a BigQuery project previously you will be asked to do so.  You will need to enter information
+   to pay for the cost of queries.  For more details see: https://cloud.google.com/resource-manager/docs/creating-managing-projects  
+4. On the left sidebar, next to "Resources", click "+ ADD DATA", followed by "Pin a project"
 ![Pin data for easy access](/img/cloud/bq/pin_data.png)
-3. In the pop up window, type `physionet-data`, and click "PIN".
+6. In the pop up window, type `physionet-data`, and click "PIN".
 ![Type physionet-data to pin the MIMIC-III data project](/img/cloud/bq/pin_physionet_data.png)
-4. In the sidebar on the left, you should now see the `physionet-data` project. Click the arrow to the left of `physionet-data` to expand the project.
-5. You should now see the following projects: `eicu_crd_demo`, `mimiciii_clinical`, `mimiciii_demo`, `mimiciii_notes`, and `mimiciii_derived`. You are ready to query the data! Try a simple query in the main dialogue box:
+6. In the sidebar on the left, you should now see the `physionet-data` project. Click the arrow to the left of `physionet-data` to expand the project.
+7. You should now see the following projects: `eicu_crd_demo`, `mimiciii_clinical`, `mimiciii_demo`, `mimiciii_notes`, and `mimiciii_derived`. Make sure you are logged in under your project that pays for queries: /bigquery?project=paying-project-name . You are ready to query the data! Try a simple query in the main dialogue box:
 
 ```sql
 SELECT *


### PR DESCRIPTION
This update does the following:

- Updates the documentation for how to use BigQuery, making it more comprehensive.  
- Moves the page about using MIMIC in the cloud under Getting started instead of under About.
- Cleans up the Getting started `_index.md` page (which controls the content of the /gettingstarted/ page), making the naming of the hyperlinks consistent with the naming used in the page navigation (on the left side of a page).    