### PR TITLE
Fixes typo in BigQuery instructions.

### DIFF
--- a/content/gettingstarted/cloud.md
+++ b/content/gettingstarted/cloud.md
@@ -94,7 +94,7 @@ Once you have requested access to using MIMIC-III on BigQuery, you need to "pin"
    to pay for the cost of queries.  For more details see: https://cloud.google.com/resource-manager/docs/creating-managing-projects  
 4. On the left sidebar, next to "Resources", click "+ ADD DATA", followed by "Pin a project"
 ![Pin data for easy access](/img/cloud/bq/pin_data.png)
-6. In the pop up window, type `physionet-data`, and click "PIN".
+5. In the pop up window, type `physionet-data`, and click "PIN".
 ![Type physionet-data to pin the MIMIC-III data project](/img/cloud/bq/pin_physionet_data.png)
 6. In the sidebar on the left, you should now see the `physionet-data` project. Click the arrow to the left of `physionet-data` to expand the project.
 7. You should now see the following projects: `eicu_crd_demo`, `mimiciii_clinical`, `mimiciii_demo`, `mimiciii_notes`, and `mimiciii_derived`. Make sure you are logged in under your project that pays for queries: /bigquery?project=paying-project-name . You are ready to query the data! Try a simple query in the main dialogue box:


### PR DESCRIPTION
This fixes a typo in the recently updated instructions for using BigQuery on the MIMIC III website.