### PR TITLE
Remove broken link from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Note on deploying the website
 
-Automatic builds have not yet been implemented. Currently deploys using the method described at: http://www.andrewcodispoti.com/deploy-process/
+Automatic builds have not yet been implemented. 
 
 ## Issues with the website or MIMIC
 


### PR DESCRIPTION
The link for how to deploy the MIMIC III website is broken.  It has been removed.