### PR TITLE
Add links to table pages from module information - about pages

### DIFF
--- a/content/en/IV/modules/core/_index.md
+++ b/content/en/IV/modules/core/_index.md
@@ -7,4 +7,6 @@ description: >
   The core module contains patient tracking data. Demographics, hospital admissions, and in-hospital ward transfers are described here.
 ---
 
-This section provides a description of the MIMIC-core module. Detailed table information is found in the [Tables](/iv/datasets) section. 
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-core module. Detailed table information is found in the [Tables](/iv/datasets/core) section.
+{{% /alert %}}

--- a/content/en/IV/modules/core/about.md
+++ b/content/en/IV/modules/core/about.md
@@ -10,3 +10,7 @@ toc = false
 The core module stores patient tracking information necessary for any data analysis using MIMIC-IV. The core module contains three tables: patients, admissions, and transfers. These tables provide demographics for the patient, a record for each hospitalization, and a record for each ward stay within a hospitalization.
 
 Notably, the patients table provides timing information for each patient through the anchor_year and anchor_year_group columns. The anchor_year is a deidentified year occurring sometime between 2100 - 2200, and the anchor_year_group is a three year long date ranges between 2008 - 2019. These pieces of information allow researchers to infer the approximate year a patient received care. For example, if a patient's anchor_year is 2158, and their anchor_year_group is 2011 - 2013, then any hospitalizations for the patient occurring in the year 2158 actually occurred sometime between 2011 - 2013. Finally, the anchor_age provides the patient age in the given anchor_year. If the patient was over 89 in the anchor_year, this anchor_age has been set to 91 (i.e. all patients over 89 have been grouped together into a single group with value 91, regardless of what their real age was).
+
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-core module. Detailed table information is found in the [Tables](/iv/datasets/core) section.
+{{% /alert %}}

--- a/content/en/IV/modules/cxr/_index.md
+++ b/content/en/IV/modules/cxr/_index.md
@@ -7,7 +7,9 @@ description: >
   The CXR module provides lookup tables linking patient identifiers with MIMIC-CXR `study_id` and `dicom_id`, allowing analysis of patient chest x-rays with the associated clinical data.
 ---
 
-This section provides a description of the MIMIC-CXR module. Detailed table information is found in the [Tables](/iv/datasets) section. 
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-CXR module. Detailed table information is found in the [Tables](/iv/datasets/cxr) section. 
+{{% /alert %}}
 
 {{% pageinfo %}}
 In order to access this module, you must sign the data use agreement for MIMIC-CXR and request access to MIMIC-CXR data on BigQuery via the [MIMIC-CXR PhysioNet project page](https://physionet.org/content/mimic-cxr/).

--- a/content/en/IV/modules/cxr/about.md
+++ b/content/en/IV/modules/cxr/about.md
@@ -26,3 +26,7 @@ MIMIC-CXR v1.0.0 was released on 22 January 2019.
 The data contains only JPG format images and 14 structured labels extracted from an NLP tool.
 As we have reorganized the data since the release of v1.0.0, we no longer distribute v1.0.0.
 The images are identical to MIMIC-CXR v2.0.0, and we will make the structured labels available again shortly.
+
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-CXR module. Detailed table information is found in the [Tables](/iv/datasets/cxr) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/ed/_index.md
+++ b/content/en/IV/modules/ed/_index.md
@@ -7,7 +7,9 @@ description: >
   The ED module contains data for emergency department patients collected while they are in the ED. Information includes reason for admission, triage assessment, vital signs, and medicine reconciliaton.
 ---
 
-This section provides a description of the MIMIC-ED module. Detailed table information is found in the [Tables](/iv/datasets) section. 
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-ED module. Detailed table information is found in the [Tables](/iv/datasets/ed) section. 
+{{% /alert %}}
 
 {{% pageinfo %}}
 MIMIC-ED is currently not publicly available.

--- a/content/en/IV/modules/ed/about.md
+++ b/content/en/IV/modules/ed/about.md
@@ -8,3 +8,7 @@ toc = false
 +++
 
 Information about the MIMIC-ED module will be provided upon its public release.
+
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-ED module. Detailed table information is found in the [Tables](/iv/datasets/ed) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/hosp/_index.md
+++ b/content/en/IV/modules/hosp/_index.md
@@ -7,4 +7,6 @@ description: >
   The hosp module provides all data acquired from the hospital wide electronic health record. Information covered includes laboratory measurements, microbiology, medication administration, and billed diagnoses.
 ---
 
-This section provides a description of the MIMIC-hosp module. Detailed table information is found in the [Tables](/iv/datasets) section. 
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-hosp module. Detailed table information is found in the [Tables](/iv/datasets/hosp) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/hosp/about.md
+++ b/content/en/IV/modules/hosp/about.md
@@ -8,3 +8,7 @@ toc = false
 +++
 
 The hosp module contains data derived from the hospital wide EHR. These measurements are predominantly recorded during the hospital stay, though some tables include data from outside the hospital as well (e.g. outpatient laboratory tests in labevents). Information includes laboratory measurements (labevents, d_labitems), microbiology cultures (microbiologyevents, d_micro), provider orders (poe, poe_detail), medication administration (emar, emar_detail), medication prescription (prescriptions, pharmacy), hospital billing information (diagnoses_icd, d_icd_diagnoses, procedures_icd, d_icd_procedures, hcpcsevents, d_hcpcs, drgcodes), and service related information (services).
+
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-hosp module. Detailed table information is found in the [Tables](/iv/datasets/hosp) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/icu/_index.md
+++ b/content/en/IV/modules/icu/_index.md
@@ -7,4 +7,6 @@ description: >
   The ICU module contains information collected from the clinical information system used within the ICU. Documented data includes intravenous administrations, ventilator settings, and other charted items.
 ---
 
-This section provides a description of the MIMIC-ICU module. Detailed table information is found in the [Tables](/iv/datasets) section. 
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-ICU module. Detailed table information is found in the [Tables](/iv/datasets/icu) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/icu/about.md
+++ b/content/en/IV/modules/icu/about.md
@@ -9,4 +9,6 @@ toc = false
 
 The ICU module contains data sourced from the clinical information system at the BIDMC: MetaVision (iMDSoft). MetaVision tables were denormalized to create a star schema where the icustays and d_items tables link to a set of data tables all suffixed with "events". Data documented in the icu module includes intravenous and fluid inputs (inputevents), patient outputs (outputevents), procedures (procedureevents), information documented as a date or time (datetimeevents), and other charted information (chartevents). All events tables contain a stay_id column allowing identification of the associated ICU patient in icustays, and an itemid column allowing identification of the concept documented in d_items.
 
-
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-ICU module. Detailed table information is found in the [Tables](/iv/datasets/icu) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/note/_index.md
+++ b/content/en/IV/modules/note/_index.md
@@ -8,4 +8,6 @@ description: >
 
 ---
 
-This section provides a description of the MIMIC-note module. Detailed table information is found in the [Tables](/iv/datasets) section. 
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-note module. Detailed table information is found in the [Tables](/iv/datasets/note) section. 
+{{% /alert %}}

--- a/content/en/IV/modules/note/about.md
+++ b/content/en/IV/modules/note/about.md
@@ -10,3 +10,7 @@ toc = false
 The core module stores patient tracking information necessary for any data analysis using MIMIC-IV. The core module contains three tables: patients, admissions, and transfers. These tables provide demographics for the patient, a record for each hospitalization, and a record for each ward stay within a hospitalization.
 
 Notably, the patients table provides timing information for each patient through the anchor_year and anchor_year_group columns. The anchor_year is a deidentified year occurring sometime between 2100 - 2200, and the anchor_year_group is a three year long date ranges between 2008 - 2019. These pieces of information allow researchers to infer the approximate year a patient received care. For example, if a patient's anchor_year is 2158, and their anchor_year_group is 2011 - 2013, then any hospitalizations for the patient occurring in the year 2158 actually occurred sometime between 2011 - 2013. Finally, the anchor_age provides the patient age in the given anchor_year. If the patient was over 89 in the anchor_year, this anchor_age has been set to 91 (i.e. all patients over 89 have been grouped together into a single group with value 91, regardless of what their real age was).
+
+{{% alert title="Tables" color="primary" %}}
+This section provides a description of the MIMIC-note module. Detailed table information is found in the [Tables](/iv/datasets/note) section. 
+{{% /alert %}}


### PR DESCRIPTION
This adds links from the mimic-iv module information - about pages to their corresponding tables page.