### PR TITLE
Fix frontpage links for the mimic components.

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -26,29 +26,29 @@ MIMIC-IV is separated into "modules" to reflect the provenance of the data.
 {{% /blocks/lead %}}
 
 {{< blocks/section color="primary-light" >}}
-{{% blocks/feature icon="fa-lightbulb" title="MIMIC-Core" url="/iv/modules/core" %}}
+{{% blocks/feature icon="fa-lightbulb" title="MIMIC-Core" url="/iv/datasets/core" %}}
 Patient demographics, admission tracking, and stay information is available in MIMIC-Core.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="MIMIC-Hosp" url="/iv/modules/hosp" %}}
+{{% blocks/feature icon="fa-lightbulb" title="MIMIC-Hosp" url="/iv/datasets/hosp" %}}
 The Hosp module provides all data acquired from the hospital wide electronic health record.
 This includes laboratory measurements, microbiology cultures, medication information, services provided, billed diagnoses and procedures, and so on.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="MIMIC-ICU" url="/iv/modules/icu" %}}
+{{% blocks/feature icon="fa-lightbulb" title="MIMIC-ICU" url="/iv/datasets/icu" %}}
 The ICU module contains information collected from the clinical information system used within the ICU.
 This includes highly granular information such as hour-to-hour vital signs, information about fluid management, and other charted observations.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="MIMIC-ED" url="/iv/modules/ed" %}}
+{{% blocks/feature icon="fa-lightbulb" title="MIMIC-ED" url="/iv/datasets/ed" %}}
 The ED module contains data for emergency department patients including a triage assessment, nurse-validated vital signs, medicine reconciliation, and treatment information.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="MIMIC-CXR" url="/iv/modules/cxr" %}}
+{{% blocks/feature icon="fa-lightbulb" title="MIMIC-CXR" url="/iv/datasets/cxr" %}}
 MIMIC-cxr provides chest x-ray images and radiology reports for a subset of patients admitted to the emergency department.
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-lightbulb" title="MIMIC-Note" url="/iv/modules/note" %}}
+{{% blocks/feature icon="fa-lightbulb" title="MIMIC-Note" url="/iv/datasets/note" %}}
 The Note module contains deidentified free-text clinical notes for hospitalized patients.
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
Refer them to `/datasets/component_name` since `/modules/component_name` has been removed.