### PR TITLE
Fix github links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -98,12 +98,16 @@ version = "1.0"
 url_latest_version = "https://mimic.mit.edu"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/MIT-LCP/mimic-code"
+github_repo = "https://github.com/MIT-LCP/mimic-website"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = ""
 
 # Specify a value here if your content directory is not in your repo's root directory
 github_subdir = "/"
+
+# Uncomment this if you have a newer GitHub repo with "main" as the default branch,
+# or specify a new value if you want to reference another branch in your GitHub links
+github_branch= "main"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = ""


### PR DESCRIPTION
The github links on the right side of all pages were broken.  I fixed the "Edit this page" and "Create child page" links by using these settings in the `[params]` of the `config.toml`:

- `github_repo = "https://github.com/MIT-LCP/mimic-website"`
- `github_branch= "main"`

To make the "Create documentation issue" link compatible we have also decided to turn issues on in the mimic-website repo again.  

