### PR TITLE
Update notices regarding public/private datasets

### DIFF
--- a/content/en/IV/_index.md
+++ b/content/en/IV/_index.md
@@ -25,8 +25,13 @@ MIMIC-IV is separated into "modules" to reflect the provenance of the data. Ther
 - [core](/iv/datasets/core) - patient stay information (i.e. admissions and transfers)
 - [hosp](/iv/datasets/hosp) - hospital level data for patients: labs, micro, and electronic medication administration
 - [icu](/iv/datasets/icu) - ICU level data. These are the event tables, and are identical in structure to MIMIC-III (chartevents, etc)
-- [ed](/iv/datasets/ed) - data from the emergency department (TBD: currently not public.)
+- [ed](/iv/datasets/ed) - data from the emergency department
 - [cxr](/iv/datasets/cxr) - lookup tables and meta-data from MIMIC-CXR, allowing linking to MIMIC-IV
+- [note](/iv/datasets/note) - deidentified free-text clinical notes
+
+{{% pageinfo %}}
+MIMIC-Note is currently not publicly available and the structure is subject to change.
+{{% /pageinfo %}}
 
 All patients across all datasets are in `mimic_core`. However, not all ICU patients have ED data, not all ICU patients have CXRs, not all ED patients have hospital data, and so on. Within an individual dataset, there are also incomplete tables as certain electronic systems did not exist in the past. For example, eMAR data is only available from 2015 onward.
 

--- a/content/en/IV/datasets/core/_index.md
+++ b/content/en/IV/datasets/core/_index.md
@@ -4,9 +4,9 @@ linkTitle: "Core"
 date: 2020-08-10
 weight: 10
 description: >
-  The core module contains patient tracking data. Demographics, hospital admissions, and in-hospital ward transfers are described here.
+  The Core module contains patient tracking data. Demographics, hospital admissions, and in-hospital ward transfers are described here.
 ---
 
-The core module contains three tables: patients, admissions, and transfers. These tables provide demographics for the patient, a record for each hospitalization, and a record for each ward stay within a hospitalization.
+The Core module contains three tables: patients, admissions, and transfers. These tables provide demographics for the patient, a record for each hospitalization, and a record for each ward stay within a hospitalization.
 
 Notably, the patients table provides timing information for each patient through the anchor_year and anchor_year_group columns. The anchor_year is a deidentified year occurring sometime between 2100 - 2200, and the anchor_year_group is a three year long date ranges between 2008 - 2019. These pieces of information allow researchers to infer the approximate year a patient received care. For example, if a patient's anchor_year is 2158, and their anchor_year_group is 2011 - 2013, then any hospitalizations for the patient occurring in the year 2158 actually occurred sometime between 2011 - 2013. Finally, the anchor_age provides the patient age in the given anchor_year. If the patient was over 89 in the anchor_year, this anchor_age has been set to 91 (i.e. all patients over 89 have been grouped together into a single group with value 91, regardless of what their real age was).

--- a/content/en/IV/datasets/ed/_index.md
+++ b/content/en/IV/datasets/ed/_index.md
@@ -6,7 +6,3 @@ weight: 40
 description: >
   The ED module contains data for emergency department patients collected while they are in the ED. Information includes reason for admission, triage assessment, vital signs, and medicine reconciliaton.
 ---
-
-{{% pageinfo %}}
-MIMIC-ED is currently not publicly available and the structure is subject to change.
-{{% /pageinfo %}}

--- a/content/en/IV/datasets/note/_index.md
+++ b/content/en/IV/datasets/note/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Note"
 date: 2020-08-10
 weight: 80
 description: >
- The Note module contains deidentified free-text clinical notes for hospitalized patients.
+ (NOT PUBLICLY AVAILABLE): The Note module contains deidentified free-text clinical notes for hospitalized patients.
 ---
 
 {{% pageinfo %}}

--- a/content/en/IV/datasets/note/_index.md
+++ b/content/en/IV/datasets/note/_index.md
@@ -6,3 +6,7 @@ weight: 80
 description: >
  The Note module contains deidentified free-text clinical notes for hospitalized patients.
 ---
+
+{{% pageinfo %}}
+MIMIC-Note is currently not publicly available and the structure is subject to change.
+{{% /pageinfo %}}


### PR DESCRIPTION
* Removes notices that MIMIC-ED is not public
* Adds notices that MIMIC-Note is not public
* Fixes case on core module name for consistency with the other modules