### PR TITLE
Add information about Github discussions to the website

### DIFF
--- a/content/en/docs/community/contributing.md
+++ b/content/en/docs/community/contributing.md
@@ -7,10 +7,14 @@ toc = "true"
 
 +++
 
-## How do I raise an issue on the MIMIC Code Repository?
+## If I notice a problem, how do I raise an issue on the MIMIC Code Repository?
 
 To raise an issue, first navigate to the [MIMIC Code Repository issues page](https://github.com/MIT-LCP/mimic-code/issues).
 After logging in to GitHub, click "New issue", add a title and description of the problem, and then select the "Submit new issue" button.
+
+## How do I ask questions about MIMIC?
+
+Discussions can be used to seek advice for how to do something within the MIMIC ecosystem. If you have a question about how to do something but don't think there is a problem with the code you can use [discussions](https://github.com/MIT-LCP/mimic-code/discussions) instead of issues. If you know the answer to a question being asked in discussions we appreciate you taking the time to answer it!
 
 ## How can I help to improve the MIMIC website and documentation?
 

--- a/content/en/docs/gettingstarted/cloud/bigquery.md
+++ b/content/en/docs/gettingstarted/cloud/bigquery.md
@@ -66,4 +66,4 @@ Please (1) double check you have entered your cloud information into your Physio
 
 ## I have a different issue
 
-If none of the above have the answer, feel free to [raise an issue at the MIMIC repository](https://github.com/MIT-LCP/mimic-code/issues).
+If none of the above have the answer, feel free to [raise an issue](https://github.com/MIT-LCP/mimic-code/issues) or [ask for advice](https://github.com/MIT-LCP/mimic-code/discussions) in the MIMIC repository.

--- a/content/en/docs/help/_index.md
+++ b/content/en/docs/help/_index.md
@@ -12,31 +12,31 @@ cascade:
 
 MIMIC is provided through the work of researchers at the MIT Laboratory for Computational Physiology and [our collaborators](/docs/about/acknowledgments/). We have limited resources and cannot provide individual support to researchers worldwide.
 
-## How can I find an answer to my question?
+## How can I find an answer to my question or investigate a problem?
 
-We recommend searching the [MIMIC Code Repository GitHub issues page](https://github.com/MIT-LCP/mimic-code/issues) for your question.
-The page already contains a number of useful discussions around nuanced aspects of the data.
+We recommend searching the MIMIC Code Repository GitHub [issues](https://github.com/MIT-LCP/mimic-code/issues) and [discussions](https://github.com/MIT-LCP/mimic-code/discussions) pages for your problem or question.
+These pages already contains a number of useful discussions around nuanced aspects of the data.
+
+## How can I get help with setup and analysis?
+
+MIMIC is a complex dataset and we understand that there are many open questions, both in terms of the data and its analysis.
+We encourage MIMIC users to work together as a community, and actively participate in the discussion.
+If you are seeking advice for a specific question, we would suggest using discussions on the MIMIC Code Repository.
+Please demonstrate that you have investigated the question yourself! Simply asking "how do I find X in MIMIC" is unlikely to garner any useful response, since it's unclear what you have or have not tried yet.
+
+## How can I highlight an issue relating to the MIMIC dataset?
+
+If you identify an issue with the MIMIC data (for example, errors in the data, unusual characteristics, etc), we suggest raising an issue on the MIMIC Code Repository.
+
+## How do I raise an issue or ask for help on the MIMIC Code Repository?
+
+See the [contributing section](/docs/community/contributing/) for information about raising issues or asking for help.
 
 ## How can I contribute my work to the community?
 
 Contributing is easy!
 Both the [website documentation](https://github.com/MIT-LCP/mimic-website/) and the [code repository](https://github.com/MIT-LCP/mimic-code/) are openly collaborated upon via GitHub - and your contributions are welcome.
 See [our notes on how to get involved](/docs/community/contributing/) for further information.
-
-## How can I get help with my analysis?
-
-MIMIC is a complex dataset and we understand that there are many open questions, both in terms of the data and its analysis.
-We encourage MIMIC users to work together as a community, and actively participate in the discussion.
-If you are seeking advice for a specific question, we would suggest raising an issue on the [MIMIC Code Repository](https://github.com/MIT-LCP/mimic-code/issues).
-Please demonstrate that you have investigated the question yourself! Simply asking "how do I find X in MIMIC" is unlikely to garner any useful response, since it's unclear what you have or have not tried yet.
-
-## How can I highlight an issue relating to the MIMIC dataset?
-
-If you identify an issue with the MIMIC data (for example, errors in the data, unusual characteristics, etc), we suggest raising an issue on the [MIMIC Code Repository](https://github.com/MIT-LCP/mimic-code/issues).
-
-## How do I raise an issue on the MIMIC Code Repository?
-
-See the [contributing section](/docs/community/contributing/) for information about raising issues.
 
 ## What if I have found something that may involve sensitive information?
 


### PR DESCRIPTION
Update content to highlight when to use Discussions on the mimic-code repo.