### PR TITLE
Add information to make it clear that MIMIC-CXR and MIMIC-ED can be linked to other MIMIC-IV modules

### DIFF
--- a/content/en/docs/IV/modules/cxr/_index.md
+++ b/content/en/docs/IV/modules/cxr/_index.md
@@ -4,7 +4,7 @@ linkTitle: "CXR"
 date: 2020-08-10
 weight: 50
 description: >
-  The CXR module provides lookup tables linking patient identifiers with MIMIC-CXR `study_id` and `dicom_id`, allowing analysis of patient chest x-rays with the associated clinical data.
+  The CXR module provides lookup tables linking patient identifiers with MIMIC-CXR `study_id` and `dicom_id`, allowing analysis of patient chest x-rays to be linked with the clinical data from other MIMIC-IV modules.  
 ---
 
 

--- a/content/en/docs/IV/modules/ed/_index.md
+++ b/content/en/docs/IV/modules/ed/_index.md
@@ -4,5 +4,5 @@ linkTitle: "ED"
 date: 2020-08-10
 weight: 40
 description: >
-  The ED module contains data for emergency department patients collected while they are in the ED. Information includes reason for admission, triage assessment, vital signs, and medicine reconciliaton.
+  The ED module contains data for emergency department patients collected while they are in the ED. Information includes reason for admission, triage assessment, vital signs, and medicine reconciliaton. Patient identifiers allow MIMIC-ED to be linked to other MIMIC-IV modules.
 ---


### PR DESCRIPTION
The descriptions for the main pages for MIMIC-CXR and MIMIC-ED were updated accordingly. 