### PR TITLE
Adding hyperlink to public discussion in text under Community heading

### DIFF
--- a/content/en/docs/community/_index.md
+++ b/content/en/docs/community/_index.md
@@ -14,5 +14,5 @@ menu:
 
 MIMIC is provided through the work of researchers at the MIT Laboratory for Computational Physiology and [our collaborators](/docs/about/acknowledgments/). We have limited resources and cannot provide individual support to researchers worldwide. We therefore encourage MIMIC users to work together as a community.
 The [MIMIC Code Repository](https://github.com/MIT-LCP/mimic-code/) contains collaboratively developed code for a large number of useful concepts in MIMIC.
-The issues page provides a forum for [public discussion](https://github.com/MIT-LCP/mimic-code/discussions) which reaches a larger audience, enables wider discourse, and full transparency around discussions.
+The discussions page provides a forum for [public discussion](https://github.com/MIT-LCP/mimic-code/discussions) which reaches a larger audience, enables wider discourse, and full transparency around discussions.
 

--- a/content/en/docs/community/_index.md
+++ b/content/en/docs/community/_index.md
@@ -14,5 +14,5 @@ menu:
 
 MIMIC is provided through the work of researchers at the MIT Laboratory for Computational Physiology and [our collaborators](/docs/about/acknowledgments/). We have limited resources and cannot provide individual support to researchers worldwide. We therefore encourage MIMIC users to work together as a community.
 The [MIMIC Code Repository](https://github.com/MIT-LCP/mimic-code/) contains collaboratively developed code for a large number of useful concepts in MIMIC.
-The issues page provides a forum for public discussion which reaches a larger audience, enables wider discourse, and full transparency around discussions.
+The issues page provides a forum for [public discussion](https://github.com/MIT-LCP/mimic-code/discussions) which reaches a larger audience, enables wider discourse, and full transparency around discussions.
 


### PR DESCRIPTION
We recently added github discussion to allow users to ask questions about MIMIC.  This pull request adds a link to the discussion page directly from the main community page to direct users to the MIMIC discussion forum.