### PR TITLE
Updates outputevents table ref #138

### DIFF
--- a/content/en/docs/IV/modules/icu/outputevents.md
+++ b/content/en/docs/IV/modules/icu/outputevents.md
@@ -37,7 +37,6 @@ storetime | Date with times
 itemid | Integer
 value | Floating point number
 valueuom | Text
-warning | Binary (0 or 1)
 
 # Detailed Description
 


### PR DESCRIPTION
This change removes the `warning` column from the outputevents table, fixes #138.