### PR TITLE
Fix typo in procedureevents page for MIMIC-IV

### DIFF
--- a/content/en/docs/IV/modules/icu/procedureevents.md
+++ b/content/en/docs/IV/modules/icu/procedureevents.md
@@ -30,7 +30,6 @@ description: >
 
 Name | Data type
 ---- | --------
-<<<<<<< HEAD
 subject\_id | Integer
 hadm\_id | Integer
 stay\_id | Integer


### PR DESCRIPTION
Remove table row which had HEAD written in it 