### PR TITLE
Update MIMIC-IV-ED documentation

### DIFF
--- a/content/en/docs/IV/modules/ed/diagnosis.md
+++ b/content/en/docs/IV/modules/ed/diagnosis.md
@@ -1,0 +1,56 @@
+---
+title: "diagnosis table"
+date: 2020-08-10
+weight: 1
+description: >
+  diagnosis table
+---
+
+# The *diagnosis* table
+
+The *diagnosis* table provides billed diagnoses for patients. Diagnoses are determined after discharge from the emergency department.
+
+**Table source:** Emergency department information system.
+
+**Table purpose:** Track patient admissions to the emergency department.
+
+**Number of rows:** 949,172
+
+**Links to:**
+
+* *edstays* on `stay_id`
+
+# Table columns
+
+Name | Postgres data type
+---- | ----
+`subject_id`    | INTEGER NOT NULL
+`stay_id`       | INTEGER NOT NULL
+`seq_num`       | INTEGER NOT NULL
+`icd_code`      | VARCHAR(10) NOT NULL
+`icd_version`   | INTEGER NOT NULL
+`icd_title`     | VARCHAR(255) NOT NULL
+
+## `subject_id`
+
+`subject_id` is a unique identifier which specifies an individual patient. Any rows associated with a single `subject_id` pertain to the same individual.
+
+## `stay_id`
+
+An identifier which uniquely identifies a single emergency department stay for a single patient.
+
+## `seq_num`
+
+A pseudo-priority for the diagnosis. A `seq_num` of 1 usually indicates a "primary" diagnosis, but accurately assessing the priority for patients with multiple diagnoses is challenging.
+
+## `icd_code`
+
+A coded diagnosis using the International Classification of Diseases (ICD) ontology.
+
+## `icd_version`
+
+The version of the ICD system used; either 9 indicating ICD-9 or 10 indicating ICD-10. The ontologies for these two systems differ, and therefore the meaning of the `icd_code` will depend on the `icd_version`.
+
+## `icd_title`
+
+The textual description of the diagnosis.

--- a/content/en/docs/IV/modules/ed/edstays.md
+++ b/content/en/docs/IV/modules/ed/edstays.md
@@ -6,17 +6,17 @@ description: >
   edstays table
 ---
 
-# The MAIN table
+# The *edstays* table
 
-The MAIN table is the primary tracking table for emergency department visits.
+The *edstays* table is the primary tracking table for emergency department visits.
 It provides the time the patient entered the emergency department and the time they left the emergency department.
 It also provides a set of diagnoses assigned for the patient.
 
-**Table source:** Emergency department database.
+**Table source:** Emergency department information system.
 
 **Table purpose:** Track patient admissions to the emergency department.
 
-**Number of rows:** 
+**Number of rows:** 448,972
 
 **Links to:**
 
@@ -27,32 +27,20 @@ It also provides a set of diagnoses assigned for the patient.
 Name | Postgres data type
 ---- | ----
 `subject_id` | INTEGER NOT NULL
+`hadm_id`    | INTEGER NOT NULL
 `stay_id`    | INTEGER NOT NULL
 `intime`     | TIMESTAMP(0) NOT NULL
 `outtime`    | TIMESTAMP(0) NOT NULL
-`sex`        | CHAR(1) NOT NULL
-`dx1`        | VARCHAR(255)
-`dx1_icd`    | VARCHAR(10)
-`dx2`        | VARCHAR(255)
-`dx2_icd`    | VARCHAR(10)
-`dx3`        | VARCHAR(255)
-`dx3_icd`    | VARCHAR(10)
-`dx4`        | VARCHAR(255)
-`dx4_icd`    | VARCHAR(10)
-`dx5`        | VARCHAR(255)
-`dx5_icd`    | VARCHAR(10)
-`dx6`        | VARCHAR(255)
-`dx6_icd`    | VARCHAR(10)
-`dx7`        | VARCHAR(255)
-`dx7_icd`    | VARCHAR(10)
-`dx8`        | VARCHAR(255)
-`dx8_icd`    | VARCHAR(10)
-`dx9`        | VARCHAR(255)
-`dx9_icd`    | VARCHAR(10)
 
 ## `subject_id`
 
 `subject_id` is a unique identifier which specifies an individual patient. Any rows associated with a single `subject_id` pertain to the same individual.
+
+## `hadm_id`
+
+If the patient was admitted to the hospital after their ED stay, `hadm_id` will contain the hospital identifier (ranges from 2000000 - 2999999). The `hadm_id` may be used to link the ED stay with the hospitalization in MIMIC-IV.
+
+If `hadm_id` is `NULL`, the patient was not admitted to the hospital after their ED stay.
 
 ## `stay_id`
 
@@ -61,11 +49,3 @@ An identifier which uniquely identifies a single emergency department stay for a
 ## `intime`, `outtime`
 
 The admission datetime (`intime`) and discharge datetime (`outtime`) of the given emergency department stay.
-
-## `dx1_icd`, `dx2_icd`, ... `dx9_icd`
-
-The ICD coded diagnoses for the patient, ordered by priority.
-
-## `dx1`, `dx2`, ..., `dx9`
-
-The textual description of ICD diagnoses for the patient.

--- a/content/en/docs/IV/modules/ed/medrecon.md
+++ b/content/en/docs/IV/modules/ed/medrecon.md
@@ -6,19 +6,19 @@ description: >
   medrecon table
 ---
 
-# The MEDRECON table
+# The *medrecon* table
 
-On admission to the emergency departments, staff will ask the patient what current medications they are taking. This process is called medicine reconciliation, and the MEDRECON table stores the findings of the care providers.
+On admission to the emergency departments, staff will ask the patient what current medications they are taking. This process is called medicine reconciliation, and the *medrecon* table stores the findings of the care providers.
 
-**Table source:** Emergency department database.
+**Table source:** Emergency department information system.
 
 **Table purpose:** Document medications a patient is currently taking.
 
-**Number of rows:** 
+**Number of rows:** 3,147,294
 
 **Links to:**
 
-* MAIN on `stay_id`
+* *edstays* on `stay_id`
 
 <!-- # Important considerations -->
 
@@ -26,7 +26,8 @@ On admission to the emergency departments, staff will ask the patient what curre
 
 Name | Postgres data type
 ---- | ----
-`stay_id`         | INT NOT NULL
+`subject_id`      | INTEGER NOT NULL
+`stay_id`         | INTEGER NOT NULL
 `charttime`       | TIMESTAMP(0)
 `name`            | VARCHAR(255)
 `gsn`             | VARCHAR(10)
@@ -34,6 +35,10 @@ Name | Postgres data type
 `etc_rn`          | SMALLINT NOT NULL
 `etccode`         | VARCHAR(8)
 `etcdescription`  | VARCHAR(255)
+
+## `subject_id`
+
+`subject_id` is a unique identifier which specifies an individual patient. Any rows associated with a single `subject_id` pertain to the same individual.
 
 ## `stay_id`
 
@@ -49,7 +54,7 @@ The name of the medication.
 
 ## `gsn`
 
-A code for the medication.
+The Generic Sequence Number (GSN), an ontology for the medication.
 
 ## `ndc`
 
@@ -57,4 +62,4 @@ The National Drug Code (ndc) for the medication.
 
 ## `etc_rn`, `etccode`, `etcdescription`
 
-Medications are grouped using a hierarchical ontology. As more than one group may be associated with the medication, `etc_rn` is used to differentiate the groups (there is no meaning to the order of `etc_rn`). `etccode` provides the code and `etcdescription` provides the description of the group.
+Medications are grouped using a hierarchical ontology known as the Enhanced Therapeutic Class (ETC). As more than one group may be associated with the medication, a sequential integer (`etc_rn`) was generated to differentiate the groups. There is no meaning to the order of `etc_rn`. `etccode` provides the code and `etcdescription` provides the description of the group.

--- a/content/en/docs/IV/modules/ed/pyxis.md
+++ b/content/en/docs/IV/modules/ed/pyxis.md
@@ -6,19 +6,21 @@ description: >
   pyxis table
 ---
 
-# The PYXIS table
+# The *pyxis* table
 
-The PYXIS table provides information for medicine administrations made via the Pyxis system.
+The *pyxis* table provides information for medicine dispensations made via the Pyxis system.
 
-**Table source:** Emergency department database.
+Note that as the same medication may have multiple `gsn` values, each row does *not* necessarily indicate a unique dispensation. The `med_rn` column allows for subselecting to individual dispensations.
+
+**Table source:** Emergency department information system.
 
 **Table purpose:** Track medicine administrations.
 
-**Number of rows:** 
+**Number of rows:** 1,674,652
 
 **Links to:**
 
-* MAIN on `stay_id`
+* *edstays* on `stay_id`
 
 <!-- # Important considerations -->
 
@@ -26,13 +28,18 @@ The PYXIS table provides information for medicine administrations made via the P
 
 Name | Postgres data type
 ---- | ----
-`stay_id`   | INT NOT NULL
+`subject_id` | INTEGER NOT NULL
+`stay_id`   | INTEGER NOT NULL
 `charttime` | TIMESTAMP(0)
 `med_rn`    | SMALLINT NOT NULL
 `name`      | VARCHAR(255)
 `ifu`       | VARCHAR(255)
 `gsn_rn`    | SMALLINT NOT NULL
 `gsn`       | VARCHAR(10)
+
+## `subject_id`
+
+`subject_id` is a unique identifier which specifies an individual patient. Any rows associated with a single `subject_id` pertain to the same individual.
 
 ## `stay_id`
 
@@ -44,18 +51,16 @@ The time at which the medication was charted, which is the closest approximation
 
 ## `med_rn`
 
-A row number for the medicine.
+A row number for the medicine used to group single dispensations.
 
 ## `name`
 
 The name of the medicine.
 
-## `ifu`
-
 ## `gsn`
 
-A hierarchical ontology which groups the medication.
+The Generic Sequence Number (GSN), an ontology which provides a code for each medicine.
 
 ## `gsn_rn`
 
-As a medicine may be a member of multiple groups in the GSN ontology, this row number differentiates them.
+As a medicine may be a member of multiple groups in the GSN ontology, this row number differentiates them. The order of `gsn_rn` has no meaning.

--- a/content/en/docs/IV/modules/ed/triage.md
+++ b/content/en/docs/IV/modules/ed/triage.md
@@ -14,7 +14,7 @@ Their vital signs are measured and a level of acuity is assigned. Based on the l
 
 All fields in *triage* were originally free-text. For deidentification purposes, the vital sign and pain fields were converted into a numeric value. As a result, a small number of `NULL` values were introduced for text entries.
 
-**Table source:** Emergency department database.
+**Table source:** Emergency department information system.
 
 **Table purpose:** 
 
@@ -54,7 +54,7 @@ An identifier which uniquely identifies a single emergency department stay for a
 
 ## `temperature`
 
-The patient's temperature in degrees Celsius. Incorrect documentation in Fahrenheit may occur.
+The patient's temperature in degrees Farenheit. Some temperatures may be incorrectly documented as Celsius.
 
 ## `heartrate`
 

--- a/content/en/docs/IV/modules/ed/vitalsign.md
+++ b/content/en/docs/IV/modules/ed/vitalsign.md
@@ -6,20 +6,19 @@ description: >
   vitalsign table
 ---
 
+# The *vitalsign* table
 
-# The VITALSIGN table
+Patients admitted to the emergency department have routine vital signs taken ever 1-4 hours. These vital signs are stored in the *vitalsign* table.
 
-Patients admitted to the emergency department have routine vital signs taken ever 1-4 hours. These vital signs are stored in the VITALSIGN table.
-
-**Table source:** Emergency department database.
+**Table source:** Emergency department information system.
 
 **Table purpose:** Provides nurse documented vital signs.
 
-**Number of rows:** 
+**Number of rows:** 1,651,119.
 
 **Links to:**
 
-* MAIN on `stay_id`
+* *edstays* on `stay_id`
 
 <!-- # Important considerations -->
 
@@ -27,16 +26,21 @@ Patients admitted to the emergency department have routine vital signs taken eve
 
 Name | Postgres data type
 ---- | ----
-`stay_id`   | INTEGER NOT NULL
-`charttime` | TIMESTAMP(0)
-`temp`      | NUMERIC(10, 4)
-`pulse`     | NUMERIC(10, 4)
-`SBP`       | INTEGER
-`DBP`       | INTEGER
-`RR`        | NUMERIC(10, 4)
-`O2Sat`     | NUMERIC(10, 4)
-`Rhythm`    | TEXT
-`Pain`      | TEXT
+`subject_id`  | INTEGER NOT NULL
+`stay_id`     | INTEGER NOT NULL
+`charttime`   | TIMESTAMP(0)
+`temperature` | NUMERIC(10, 4)
+`heartrate`   | NUMERIC(10, 4)
+`resprate`    | NUMERIC(10, 4)
+`o2sat`       | NUMERIC(10, 4)
+`sbp`         | INTEGER
+`dbp`         | INTEGER
+`rhythm`      | TEXT
+`pain`        | TEXT
+
+## `subject_id`
+
+`subject_id` is a unique identifier which specifies an individual patient. Any rows associated with a single `subject_id` pertain to the same individual.
 
 ## `stay_id`
 
@@ -46,32 +50,32 @@ An identifier which uniquely identifies a single emergency department stay for a
 
 The time at which the vital signs were charted.
 
-## `temp`
+## `temperature`
 
-The patient's temperature.
+The patient's temperature in degrees Farenheit. Some temperatures may be incorrectly documented as Celsius.
 
-## `pulse`
+## `heartrate`
 
-The patient's heart rate.
+The patient's heart rate in beats per minute.
 
-## `sbp`, `dbp`
+## `resprate`
 
-The patient's diastolic (dbp) and systolic (sbp) blood pressure.
-
-## `rr`
-
-The patient's respiratory rate.
-
-<!-- o2flow -->
+The patient's respiratory rate in breaths per minute.
 
 ## `o2sat`
 
-The patient's peripheral oxygen saturation.
+The patient's oxygen saturation measured as a percentage.
+
+## `sbp`, `dbp`
+
+The patient's systolic (sbp) and diastolic (dbp) blood pressure measured in millimetres of mercury (mmHg).
+
+<!-- o2flow -->
 
 ## `rhythm`
 
-The patient's current heart rhythm
+The patient's heart rhythm.
 
 ## `pain`
 
-The patient's self-reported level of pain on a scale from 0-10.
+The patient's self-reported level of pain on a scale from 0-10. The pain is documented as free-text and may contain non-numeric entries.

--- a/content/en/docs/IV/modules/ed/vitalsign_hl7.md
+++ b/content/en/docs/IV/modules/ed/vitalsign_hl7.md
@@ -6,7 +6,7 @@ description: >
   vitalsign_hl7 table
 ---
 
-# The VITALSIGN_HL7 table
+# The *vitalsign_hl7* table
 
 **This table is not yet populated.**
 
@@ -15,15 +15,15 @@ Minute-by-minute vital signs for telemetry are communicated to a central server 
 However, vital signs are only communicated with patient identifiers manually input into the bedside monitors, a process which is not routine practice.
 As a result, many patients who are monitored by telemetry do not have their vital signs recorded in this table.
 
-**Table source:** Emergency department database.
+**Table source:** Emergency department information system.
 
 **Table purpose:** Continuous vital signs for monitored patients.
 
-**Number of rows:** 
+**Number of rows:** 0.
 
 **Links to:**
 
-* MAIN on `stay_id`
+* *edstays* on `stay_id`
 
 <!-- # Important considerations -->
 
@@ -31,6 +31,7 @@ As a result, many patients who are monitored by telemetry do not have their vita
 
 Name | Postgres data type
 ---- | ----
+`subject_id` | INTEGER NOT NULL
 `stay_id`    | INTEGER NOT NULL
 `charttime`  | TIMESTAMP(0) NOT NULL
 `hr`         | INTEGER
@@ -40,6 +41,10 @@ Name | Postgres data type
 `nbp_d`      | INTEGER
 `nbp_m`      | INTEGER
 `nbp_s`      | INTEGER
+
+## `subject_id`
+
+`subject_id` is a unique identifier which specifies an individual patient. Any rows associated with a single `subject_id` pertain to the same individual.
 
 ## `stay_id`
 


### PR DESCRIPTION
There were lots of inconsistencies / inaccuracies in the ED documentation which I've tried to fix.

* added diagnosis table
* `subject_id` is in each table
* fixed description of `acuity`
* update many column names
* update many column descriptions