### PR TITLE
Updates links to information on the emar and prescriptions pages

### DIFF
--- a/content/en/docs/IV/modules/hosp/emar.md
+++ b/content/en/docs/IV/modules/hosp/emar.md
@@ -16,7 +16,7 @@ Records in this table are populated by bedside nursing staff scanning barcodes a
 
 * *emar_detail* on `emar_id`
 * *pharmacy* on `pharmacy_id`
-* *prescriptions* on `poe_id`
+* *prescriptions* on `poe_id` to `pharmacy_id` (via the pharmacy table)
 * *poe* on `poe_id`
 
 <!--

--- a/content/en/docs/IV/modules/hosp/prescriptions.md
+++ b/content/en/docs/IV/modules/hosp/prescriptions.md
@@ -14,7 +14,7 @@ The *prescriptions* table provides information about prescribed medications. Inf
 ## Links to
 
 * *pharmacy* on `pharmacy_id`
-* *emar* on `poe_id`
+* *emar* on `pharmacy_id` to `poe_id` (via the pharmacy table)
 
 <!--
 


### PR DESCRIPTION
This makes it clear that it is necessary to use the pharmacy table to link between `poe_id` and `pharmacy_id` for the emar and prescriptions tables. FIxes #170 .