### PR TITLE
Updated deploy production branch note

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ After the pull request of the new material is merged into the main branch of mim
 * Optional: Check if the command above ran correctly,
 Run command: `git remote -v`
 should return:
-Mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (fetch)
-Mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (push)
+mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (fetch)
+mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (push)
 origin   https://www.github.com/MIT-LCP/mimic-website (fetch)
 origin   https://www.github.com/MIT-LCP/mimic-website (push)
  
@@ -40,10 +40,10 @@ In another terminal from your mimic-website repo:
 Run command: `git push mimic-production`
 
 
- 
 * Note:
 Your public key (for the machine you're pushing from) must be in the webuser group
 
+Currently, some minor errors exist related to reading git log. If error messages show up after push to mimic-production, website deployment might still be successful. It is always good practice to check the website after deployment.
 
 ## Issues with the website or MIMIC
 

--- a/README.md
+++ b/README.md
@@ -12,38 +12,38 @@
 
 ## Note on deploying the website
 
-* 1: Add mimic-production to remote
-After the pull request of the new material is merged into the main branch of mimic-website, pull down the latest version of main to your local repo. Run the following command after filling in the IP address for server Heimdallr:
+1. Add mimic-production to remote
+   After the pull request of the new material is merged into the main branch of mimic-website, pull down the latest version of main to your  local repo. Run the following command after filling in the IP address for server Heimdallr:
  
-`git remote add mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git`
+   `git remote add mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git`
  
-* Optional: Check if the command above ran correctly,
-Run command: `git remote -v`
-should return:
-mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (fetch)
-mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (push)
-origin   https://www.github.com/MIT-LCP/mimic-website (fetch)
-origin   https://www.github.com/MIT-LCP/mimic-website (push)
+   * Optional: Check if the command above ran correctly,
+   Run command: `git remote -v`
+   should return:
+   mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (fetch)
+   mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (push)
+   origin   https://www.github.com/MIT-LCP/mimic-website (fetch)
+   origin   https://www.github.com/MIT-LCP/mimic-website (push)
  
-* 2: Sshuttle into the production server
+2. Sshuttle into the production server
  
-Run the following command after filling in the  LCP username and IP address: `alias sshcsail="sshuttle -r <LCP username>@heimdallr.csail.mit.edu <IP address for Heimdallr>/24"`
+   Run the following command after filling in the  LCP username and IP address: `alias sshcsail="sshuttle -r <LCP    username>@heimdallr.csail.mit.edu <IP address for Heimdallr>/24"`
  
-Run command: `sshcsail`
+   Run command: `sshcsail`
  
-Should return:  “client: Connected” after you enter your password
+   Should return:  “client: Connected” after you enter your password
  
-* 3: Push development
+3. Push development
  
-In another terminal from your mimic-website repo:
+   In another terminal from your mimic-website repo:
  
-Run command: `git push mimic-production`
+   Run command: `git push mimic-production`
 
 
-* Note:
-Your public key (for the machine you're pushing from) must be in the webuser group
+   * Note:
+   Your public key (for the machine you're pushing from) must be in the webuser group
 
-Currently, some minor errors exist related to reading git log. If error messages show up after push to mimic-production, website deployment might still be successful. It is always good practice to check the website after deployment.
+   Currently, some minor errors exist related to reading git log. If error messages show up after push to mimic-production, website deployment might still be successful. It is always good practice to check the website after deployment.
 
 ## Issues with the website or MIMIC
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,38 @@
 
 ## Note on deploying the website
 
-Automatic builds have not yet been implemented. 
+* 1: Add mimic-production to remote
+After the pull request of the new material is merged into the main branch of mimic-website, pull down the latest version of main to your local repo. Run the following command after filling in the IP address for server Heimdallr:
+ 
+`git remote add mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git`
+ 
+* Optional: Check if the command above ran correctly,
+Run command: `git remote -v`
+should return:
+Mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (fetch)
+Mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (push)
+origin   https://www.github.com/MIT-LCP/mimic-website (fetch)
+origin   https://www.github.com/MIT-LCP/mimic-website (push)
+ 
+* 2: Sshuttle into the production server
+ 
+Run the following command after filling in the  LCP username and IP address: `alias sshcsail="sshuttle -r <LCP username>@heimdallr.csail.mit.edu <IP address for Heimdallr>/24"`
+ 
+Run command: `sshcsail`
+ 
+Should return:  “client: Connected” after you enter your password
+ 
+* 3: Push development
+ 
+In another terminal from your mimic-website repo:
+ 
+Run command: `git push mimic-production`
+
+
+ 
+* Note:
+Your public key (for the machine you're pushing from) must be in the webuser group
+
 
 ## Issues with the website or MIMIC
 

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@
 1. Add mimic-production to remote
    After the pull request of the new material is merged into the main branch of mimic-website, pull down the latest version of main to your  local repo. Run the following command after filling in the IP address for server Heimdallr:
  
-   `git remote add mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git`
+   `git remote add mimic-production webuser@<IP address for Webserver>:/home/webuser/mimic-website.git`
  
    * Optional: Check if the command above ran correctly,
    Run command: `git remote -v`
    should return:
-   mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (fetch)
-   mimic-production webuser@<IP address for Heimdallr>:/home/webuser/mimic-website.git (push)
+   mimic-production webuser@<IP address for Webserver>:/home/webuser/mimic-website.git (fetch)
+   mimic-production webuser@<IP address for Webserver>:/home/webuser/mimic-website.git (push)
    origin   https://www.github.com/MIT-LCP/mimic-website (fetch)
    origin   https://www.github.com/MIT-LCP/mimic-website (push)
  
 2. Sshuttle into the production server
  
-   Run the following command after filling in the  LCP username and IP address: `alias sshcsail="sshuttle -r <LCP    username>@heimdallr.csail.mit.edu <IP address for Heimdallr>/24"`
+   Run the following command after filling in the  LCP username and IP address: `alias sshholyoke="sshuttle -r <LCP username>@helios.mit.edu <IP address for Webserver, replace list part with '0/24'>"`
  
-   Run command: `sshcsail`
+   Run command: `sshholyoke`
  
    Should return:  “client: Connected” after you enter your password
  
@@ -44,6 +44,8 @@
    Your public key (for the machine you're pushing from) must be in the webuser group
 
    Currently, some minor errors exist related to reading git log. If error messages show up after push to mimic-production, website deployment might still be successful. It is always good practice to check the website after deployment.
+   
+   Error message is "Failed to read Git log: fatal: not a git repository: '.'". 
 
 ## Issues with the website or MIMIC
 


### PR DESCRIPTION
Added notes at the main README file, about how to deploy the production branch of mimic-website. 

IP addresses and user names are masked. 

