### PR TITLE
Add waveform tutorial

### DIFF
--- a/content/en/docs/IV/tutorials/Waveform/_index.md
+++ b/content/en/docs/IV/tutorials/Waveform/_index.md
@@ -1,0 +1,8 @@
+---
+title: "MIMIC-IV Waveform"
+linkTitle: "Waveform"
+date: 2021-07-18
+weight: 20
+description: >
+  Tutorials for the MIMIC-IV Waveform module.
+---

--- a/content/en/docs/IV/tutorials/Waveform/waveform.md
+++ b/content/en/docs/IV/tutorials/Waveform/waveform.md
@@ -1,0 +1,14 @@
+---
+title: "Waveform Tutorial"
+linktitle: "Waveform"
+date: 2022-07-18
+weight: 1
+
+---
+
+## Working with waveforms
+
+An in-depth tutorial for working with physiological signals from the MIMIC-IV Waveform Module can be found here: 
+https://wfdb.io/mimic_wfdb_tutorials/intro.html. This tutorial was created for a workshop at the
+[EMBC](https://embc.embs.org/) in 2022. The tutorial investigates approaches for estimating cuffless blood pressure
+from the MIMIC-IV Waveform Database. 


### PR DESCRIPTION
This adds a link to the tutorial used at EMBC 2022 on MIMIC-IV Waveforms. 