### PR TITLE
Update phrasing for tutorial from IEEE EMBC

### DIFF
--- a/content/en/docs/IV/tutorials/Waveform/ieee_workshop.md
+++ b/content/en/docs/IV/tutorials/Waveform/ieee_workshop.md
@@ -1,14 +1,12 @@
 ---
-title: "Waveform Tutorial"
-linktitle: "Waveform"
+title: "IEEE EMBC Waveform Tutorial"
+linktitle: "IEEE Workshop"
 date: 2022-07-18
 weight: 1
 
 ---
 
-## Working with waveforms
-
-An in-depth tutorial for working with physiological signals from the MIMIC-IV Waveform Module can be found here: 
+An in-depth tutorial for working with physiological signals from the MIMIC-IV-Waveform Module can be found here: 
 https://wfdb.io/mimic_wfdb_tutorials/intro.html. This tutorial was created for a workshop at the
 [EMBC](https://embc.embs.org/) in 2022. The tutorial investigates approaches for estimating cuffless blood pressure
-from the MIMIC-IV Waveform Database. 
+from the MIMIC-IV-Waveform Module. 


### PR DESCRIPTION
This PR makes the phrasing for the tutorial from IEEE EMBC more specific, instead of just referring to it as a Waveform Tutorial. 