### PR TITLE
Add mit accessibility link to footer. closes #205.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -73,8 +73,9 @@ style = "tango"
 # Everything below this are Site Params
 
 [params]
-copyright = "MIT-LCP"
+copyright = "MIT Laboratory for Computational Physiology."
 privacy_policy = ""
+mit_accessibility_url = "https://accessibility.mit.edu/"
 
 # First one is picked as the Twitter card image if not set on page.
 # images = ["images/project-illustration.png"]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,66 @@
+
+
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "Previous"
+
+[ui_pager_next]
+other = "Next"
+
+[ui_read_more]
+other = "Read more"
+
+[ui_search]
+other = "Search this site…"
+
+# Used in sentences such as "Posted in News"
+[ui_in]
+other = "in"
+
+# Used in sentences such as "All Tags"
+[ui_all]
+other = "all"
+
+# Footer text
+[footer_all_rights_reserved]
+other = " "
+
+[footer_privacy_policy]
+other = ""
+
+[footer_accessibility]
+other = "For more accessibility options, see the "
+
+[footer_accessibility_link_text]
+other = "MIT Accessibility Page"
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "By"
+[post_created]
+other = "Created"
+[post_last_mod]
+other = "Last modified"
+[post_edit_this]
+other = "Edit this page"
+[post_create_child_page]
+other = "Create child page"
+[post_create_issue]
+other = "Create documentation issue"
+[post_create_project_issue]
+other = "Create project issue"
+[post_posts_in]
+other = "Posts in"
+[post_reading_time]
+other = "minute read"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,40 @@
+{{ $links := .Site.Params.links }}
+<footer class="bg-dark py-5 row d-print-none">
+  <div class="container-fluid mx-sm-5">
+    <div class="row">
+      <div class="col-6 col-sm-4 text-xs-center order-sm-2">
+        {{ with $links }}
+        {{ with index . "user"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
+        {{ with $links }}
+        {{ with index . "developer"}}
+        {{ template "footer-links-block"  . }}
+        {{ end }}
+        {{ end }}
+      </div>
+      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
+        {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
+        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+        {{ with .Site.Params.mit_accessibility_url }}<small class="text-white">{{ T "footer_accessibility" }}<a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_accessibility_link_text" }}</a>.</small>{{ end }}
+	{{ if not .Site.Params.ui.footer_about_disable }}
+		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+	{{ end }}
+      </div>
+    </div>
+  </div>
+</footer>
+{{ define "footer-links-block" }}
+<ul class="list-inline mb-0">
+  {{ range . }}
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
+      <i class="{{ .icon }}"></i>
+    </a>
+  </li>
+  {{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
We have been reminded by the MIT Accessibility Office to add a link to the footer of the website to the MIT Accessibility page: https://github.com/MIT-LCP/mimic-website/issues/205

This pull request adds the following text to the footer (by overriding a couple of the Docsy template files):

> For more accessibility options, see the [MIT Accessibility Page](https://accessibility.mit.edu/).

